### PR TITLE
Add Mesa compatibility and warnings if GL version is not sufficient

### DIFF
--- a/ReplicaSDK/include/GLCheck.h
+++ b/ReplicaSDK/include/GLCheck.h
@@ -1,0 +1,28 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#pragma once
+#include <pangolin/gl/gl.h>
+#include <pangolin/utils/log.h>
+
+namespace {
+ constexpr float minGLVersion = 4.3;
+}
+
+// Check that the runtime GL version is compatible
+bool checkGLVersion() {
+  const std::string glVersionStr(reinterpret_cast<const char*>(glGetString(GL_VERSION)));
+  
+  if(glVersionStr.empty()) {
+    pango_print_error("No openGL version found. Do you have an openGL context (e.g. from glewInit()) ?\n");
+    return false;
+  }
+  
+  if(std::stof(glVersionStr) < minGLVersion) {
+    pango_print_error("Insufficient OpenGL version: %s minimum required is %.1f\n", glVersionStr.c_str(), minGLVersion);
+    pango_print_error("Mesa users: try forcing compatibility with MESA_GL_VERSION_OVERRIDE=%.1f"
+		   " MESA_GLSL_VERSION_OVERRIDE=%d\n", minGLVersion, static_cast<int>(minGLVersion*100));
+    return false;
+  }
+  return true;
+}
+
+

--- a/ReplicaSDK/ptex/EGL.cpp
+++ b/ReplicaSDK/ptex/EGL.cpp
@@ -105,7 +105,7 @@ EGLCtx::EGLCtx(const bool createCtx, const int cudaDevice, const bool createSurf
             eglGetProcAddress("eglQueryDeviceAttribEXT"));
 
     int eglDevId = 0;
-
+    bool foundCudaDev = false;
     // Find the CUDA device asked for
     for (; eglDevId < numDevices; ++eglDevId) {
       EGLAttrib cudaDevNumber;
@@ -121,10 +121,14 @@ EGLCtx::EGLCtx(const bool createCtx, const int cudaDevice, const bool createSurf
 
     PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
         (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
-
-    display = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevs[eglDevId], 0);
+    if(foundCudaDev) {
+      display = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevs[eglDevId], 0);
+    } else {
+      Display* x11 = XOpenDisplay(NULL);
+      display = eglGetPlatformDisplayEXT(EGL_PLATFORM_X11_KHR, x11, 0);
+    }
     ASSERT(display != EGL_NO_DISPLAY, "Can't create EGL display");
-
+    
     EGLint major, minor;
     ASSERT(eglInitialize(display, &major, &minor), "Can't init EGL");
 

--- a/ReplicaSDK/shaders/atlas.glsl
+++ b/ReplicaSDK/shaders/atlas.glsl
@@ -161,32 +161,29 @@ int indexAdjacentFaces(int faceID, inout ivec2 p, int tsize)
 }
 
 // load texel from atlas, handling adjacent faces
-vec4 texelFetchAtlasAdj(sampler2D tex, int faceID, ivec2 p, int level = 0)
+vec4 texelFetchAtlasAdj(sampler2D tex, int faceID, ivec2 p)
 {
-    int tsize = tileSize >> level;
-
     // fetch from adjacent face if necessary
-    faceID = indexAdjacentFaces(faceID, p, tsize);
+    faceID = indexAdjacentFaces(faceID, p, tileSize);
 
     // clamp to tile edge
-    p = clamp(p, ivec2(0, 0), ivec2(tsize - 1, tsize - 1));
+    p = clamp(p, ivec2(0, 0), ivec2(tileSize - 1, tileSize - 1));
 
-    ivec2 atlasPos = FaceToAtlasPos(faceID, tsize);
-    return texelFetch(tex, atlasPos + p, level);
+    ivec2 atlasPos = FaceToAtlasPos(faceID, tileSize);
+    return texelFetch(tex, atlasPos + p, 0);
 }
 
 // fetch with bilinear filtering
-vec4 textureAtlas(sampler2D tex, int faceID, vec2 p, float lod = 0)
+vec4 textureAtlas(sampler2D tex, int faceID, vec2 p)
 {
-    int level = int(lod);
     p -= 0.5;
     ivec2 i = ivec2(floor(p));
     vec2 f = p - vec2(i);
-    return mix(mix(texelFetchAtlasAdj(tex, faceID, ivec2(i), level),
-                   texelFetchAtlasAdj(tex, faceID, ivec2(i.x + 1, i.y), level),
+    return mix(mix(texelFetchAtlasAdj(tex, faceID, ivec2(i)),
+                   texelFetchAtlasAdj(tex, faceID, ivec2(i.x + 1, i.y)),
                    f.x),
-               mix(texelFetchAtlasAdj(tex, faceID, ivec2(i.x, i.y + 1), level),
-                   texelFetchAtlasAdj(tex, faceID, ivec2(i.x + 1, i.y + 1), level),
+               mix(texelFetchAtlasAdj(tex, faceID, ivec2(i.x, i.y + 1)),
+                   texelFetchAtlasAdj(tex, faceID, ivec2(i.x + 1, i.y + 1)),
                    f.x),
                f.y);
 }

--- a/ReplicaSDK/src/render.cpp
+++ b/ReplicaSDK/src/render.cpp
@@ -3,7 +3,9 @@
 #include <PTexLib.h>
 #include <pangolin/image/image_convert.h>
 
+#include "GLCheck.h"
 #include "MirrorRenderer.h"
+
 
 int main(int argc, char* argv[]) {
   ASSERT(argc == 3 || argc == 4, "Usage: ./ReplicaRenderer mesh.ply /path/to/atlases [mirrorFile]");
@@ -28,6 +30,10 @@ int main(int argc, char* argv[]) {
   EGLCtx egl;
 
   egl.PrintInformation();
+  
+  if(!checkGLVersion()) {
+    return 1;
+  }
 
   //Don't draw backfaces
   const GLenum frontFace = GL_CCW;

--- a/ReplicaSDK/src/viewer.cpp
+++ b/ReplicaSDK/src/viewer.cpp
@@ -4,9 +4,11 @@
 #include <pangolin/display/display.h>
 #include <pangolin/display/widgets/widgets.h>
 
+#include "GLCheck.h"
 #include "MirrorRenderer.h"
 
 int main(int argc, char* argv[]) {
+
   ASSERT(argc == 3 || argc == 4, "Usage: ./ReplicaViewer mesh.ply textures [glass.sur]");
 
   const std::string meshFile(argv[1]);
@@ -29,6 +31,10 @@ int main(int argc, char* argv[]) {
 
   if (glewInit() != GLEW_OK) {
     pango_print_error("Unable to initialize GLEW.");
+  }
+
+  if(!checkGLVersion()) {
+    return 1;
   }
 
   // Setup default OpenGL parameters


### PR DESCRIPTION
Many users will have issues if their GL implementation is Mesa based (e.g. Ubuntu systems). Previously this would cause a silent segfault, and not allow SDK tools to run. 

This PR gives users of Mesa a helpful message, and gracefully exits rather than segfaulting.  This should resolve https://github.com/facebookresearch/Replica-Dataset/issues/40 and associated issues. 

**Tested:**
- Mesa only on Fedora
- Nvidia on Ubuntu