### PR TITLE
Fix nullptr UB in checkGLVersion

### DIFF
--- a/ReplicaSDK/include/GLCheck.h
+++ b/ReplicaSDK/include/GLCheck.h
@@ -9,12 +9,14 @@ namespace {
 
 // Check that the runtime GL version is compatible
 bool checkGLVersion() {
-  const std::string glVersionStr(reinterpret_cast<const char*>(glGetString(GL_VERSION)));
+  const GLubyte* glStr = glGetString(GL_VERSION);	  
   
-  if(glVersionStr.empty()) {
+  if(glStr == nullptr) {
     pango_print_error("No openGL version found. Do you have an openGL context (e.g. from glewInit()) ?\n");
     return false;
   }
+  
+  const std::string glVersionStr(reinterpret_cast<const char*>(glStr));
   
   if(std::stof(glVersionStr) < minGLVersion) {
     pango_print_error("Insufficient OpenGL version: %s minimum required is %.1f\n", glVersionStr.c_str(), minGLVersion);


### PR DESCRIPTION
`glGetString` may return 0, which will be cast to `nullptr`. Stuffing this into a `std::string` turns out to be UB. 

Now we just check if it's nullptr rather than if the string is empty. 

Tested: Localy. 