### PR TITLE
Fix : build erroer caused by pangolin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@
 cmake_minimum_required(VERSION 2.6.0)
 
 project(Replica)
-
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake/")
 
 set(THIRD_PARTY "${CMAKE_CURRENT_LIST_DIR}/3rdparty/")

--- a/ReplicaSDK/include/PTexLib.h
+++ b/ReplicaSDK/include/PTexLib.h
@@ -1,6 +1,6 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #pragma once
-#include <pangolin/display/opengl_render_state.h>
+#include <pangolin/gl/opengl_render_state.h>
 #include <pangolin/gl/gl.h>
 #include <pangolin/gl/glsl.h>
 #include <memory>

--- a/ReplicaSDK/src/viewer.cpp
+++ b/ReplicaSDK/src/viewer.cpp
@@ -2,7 +2,7 @@
 #include <PTexLib.h>
 
 #include <pangolin/display/display.h>
-#include <pangolin/display/widgets/widgets.h>
+#include <pangolin/display/widgets.h>
 
 #include "GLCheck.h"
 #include "MirrorRenderer.h"


### PR DESCRIPTION
I got an problem when `./build sh` 
Error caused location of opengl_render_state.h and widgets.h

So I check original repo of Pangolin and fixed the build error.